### PR TITLE
content: replace 'Sociedade' with 'Parceria' positioning

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -9,7 +9,7 @@ const About = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold mb-6">
-            <span className="text-white">Sociedade </span>
+            <span className="text-white">Parceria </span>
             <span className="text-primary-blue">sob Conduta</span>
           </h2>
           <p className="text-xl text-primary-blue font-semibold mb-8">
@@ -23,7 +23,7 @@ const About = () => {
               Nossa Filosofia de Trabalho
             </h3>
             <p className="text-lg text-gray-300 leading-relaxed max-w-4xl mx-auto">
-              Operamos como uma <span className="text-primary-blue font-semibold">sociedade ética e transparente</span>,
+              Operamos como uma <span className="text-primary-blue font-semibold">parceria ética e transparente</span>,
               onde cada projeto é conduzido com <span className="text-primary-blue font-semibold">responsabilidade integral</span>
               e <span className="text-primary-blue font-semibold">compromisso com resultados sustentáveis</span>.
               Nossos valores direcionam cada decisão técnica e estratégica.
@@ -34,7 +34,7 @@ const About = () => {
         <div className="grid lg:grid-cols-2 gap-12 items-start">
           {/* Content */}
           <div className="space-y-6">
-            <h3 className="text-2xl font-bold text-white mb-4">Modelo de Sociedade</h3>
+            <h3 className="text-2xl font-bold text-white mb-4">Modelo de Parceria</h3>
             <p className="text-lg text-gray-300 leading-relaxed">
               Estabelecemos <span className="text-primary-blue font-semibold">parcerias estratégicas</span>
               baseadas em transparência total, onde seus objetivos se tornam nossos objetivos.
@@ -100,7 +100,7 @@ const About = () => {
               🤝 Parcerias Estratégicas
             </h3>
             <p className="text-gray-300 text-sm">
-              Formamos sociedades de longo prazo baseadas em confiança mútua, transparência total e objetivos compartilhados.
+              Formamos parcerias de longo prazo baseadas em confiança mútua, transparência total e objetivos compartilhados.
             </p>
           </NeonGradientCard>
 

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -41,7 +41,7 @@ const Hero = () => {
               SEU MVP AINDA NÃO SAIU DO PAPEL?
             </h2>
             <h1 className="text-3xl md:text-5xl lg:text-6xl font-bold mb-6 leading-tight">
-              <span className="text-blue-300">Sociedade para</span>
+              <span className="text-blue-300">Parceiro de Tecnologia para</span>
               <br />
               <span className="text-blue-600 font-bold">
                 Produção de Software
@@ -60,14 +60,17 @@ const Hero = () => {
               <span className="text-primary-blue font-bold text-2xl md:text-3xl block mb-4">
                 Lançamos produtos em semanas, não em meses.
               </span>
-              Transformamos ideias em MVPs funcionais através de nossa sociedade especializada em desenvolvimento ágil,
-              cybersegurança e consultoria estratégica em IA.
             </p>
           </NeonGradientCard>
 
+          <p className="text-base md:text-lg text-gray-400 mb-8 max-w-3xl mx-auto">
+            Transformamos ideias em MVPs funcionais através de nossa parceria especializada em desenvolvimento ágil,
+            cybersegurança e consultoria estratégica em IA.
+          </p>
+
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-16">
             <a href="#software" className="btn-primary text-lg px-8 py-4 inline-block">
-              Iniciar Sociedade
+              Iniciar Parceria
             </a>
             <a href="#contato" className="btn-secondary text-lg px-8 py-4 inline-block">
               Consulta Gratuita


### PR DESCRIPTION
## Summary
- Updates positioning from "Sociedade" to "Parceiro de Tecnologia" throughout the site
- Improves text hierarchy by moving descriptive content outside cards
- Maintains consistent messaging about technology partnership approach

## Changes Made
### Hero Component
- Changed main title from "Sociedade para" to "Parceiro de Tecnologia para"
- Updated CTA button from "Iniciar Sociedade" to "Iniciar Parceria"
- Moved descriptive text outside NeonGradientCard for better visual hierarchy
- Reduced text size from `text-xl md:text-2xl` to `text-base md:text-lg`
- Applied more subtle styling with `text-gray-400`

### About Component
- Updated section title from "Sociedade sob Conduta" to "Parceria sob Conduta"
- Changed "sociedade ética e transparente" to "parceria ética e transparente"
- Updated heading from "Modelo de Sociedade" to "Modelo de Parceria"
- Replaced "sociedades de longo prazo" with "parcerias de longo prazo"

## Visual Impact
- Better content hierarchy with descriptive text outside highlighted cards
- Consistent partnership messaging throughout the site
- Maintained all existing styling and functionality

🤖 Generated with [Claude Code](https://claude.ai/code)