### PR TITLE
feat(ui): convert mobile menu from page to inline component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,6 @@ import SoftwarePage from './pages/SoftwarePage';
 import AIPage from './pages/AIPage';
 import CybersecurityPage from './pages/CybersecurityPage';
 import StartupsPage from './pages/StartupsPage';
-import MenuPage from './pages/MenuPage';
 import BlogPage from './pages/BlogPage';
 import BlogArticlePage from './pages/blog/BlogArticlePage';
 import Contact from './components/Contact';
@@ -22,7 +21,6 @@ function App() {
         <Route path="/ai" element={<AIPage />} />
         <Route path="/cybersecurity" element={<CybersecurityPage />} />
         <Route path="/startups" element={<StartupsPage />} />
-        <Route path="/menu" element={<MenuPage />} />
         <Route path="/contact" element={
           <Layout>
             <div className="pt-20">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import MobileMenu from './MobileMenu';
 
 const Header = () => {
   const [isServicesDropdownOpen, setIsServicesDropdownOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const servicesItems = [
     {
@@ -118,17 +120,23 @@ const Header = () => {
 
           {/* Mobile menu button */}
           <div className="lg:hidden">
-            <Link
-              to="/menu"
+            <button
+              onClick={() => setIsMobileMenuOpen(true)}
               className="text-white hover:text-primary-blue transition-colors duration-200 p-2"
             >
               <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
               </svg>
-            </Link>
+            </button>
           </div>
         </div>
       </div>
+
+      {/* Mobile Menu Component */}
+      <MobileMenu
+        isOpen={isMobileMenuOpen}
+        onClose={() => setIsMobileMenuOpen(false)}
+      />
 
     </header>
   );

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const MobileMenu = ({ isOpen, onClose }) => {
+  const allMenuItems = [
+    {
+      name: 'Sobre Nós',
+      href: '/about',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M16 4c0-1.11.89-2 2-2s2 .89 2 2-.89 2-2 2-2-.89-2-2zm4 18v-6h2.5l-2.54-7.63A2.002 2.002 0 0 0 18 7h-4c-.8 0-1.54.37-2 1l-3 4v6h2v7h1.5v-7H15v7h5zM12.5 11.5c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5S11 9.17 11 10s.67 1.5 1.5 1.5zM5.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm1.5 1h-2C4.01 7 3 8.01 3 9v6h1.5v7h2v-7H8V9c0-.99-.99-2-1.5-2z"/>
+        </svg>
+      )
+    },
+    {
+      name: 'Desenvolvimento de Software',
+      href: '/software',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/>
+        </svg>
+      )
+    },
+    {
+      name: 'Inteligência Artificial',
+      href: '/ai',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+        </svg>
+      )
+    },
+    {
+      name: 'Cybersegurança',
+      href: '/cybersecurity',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
+        </svg>
+      )
+    },
+    {
+      name: 'Aceleração de Startups',
+      href: '/startups',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+        </svg>
+      )
+    },
+    {
+      name: 'Blog',
+      href: '/blog',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+        </svg>
+      )
+    },
+    {
+      name: 'Contato',
+      href: '/contact',
+      icon: (
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
+        </svg>
+      )
+    }
+  ];
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black text-white">
+      {/* Header */}
+      <div className="flex justify-between items-center h-16 px-4 border-b border-gray-800">
+        <div className="text-xl font-bold text-primary-blue">
+          IT Business
+        </div>
+        <button
+          onClick={onClose}
+          className="text-gray-400 hover:text-white transition-colors duration-200 p-2"
+        >
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Menu Items */}
+      <div className="py-2">
+        {allMenuItems.map((item, index) => (
+          <Link
+            key={item.name}
+            to={item.href}
+            onClick={onClose}
+            className="flex items-center px-4 py-4 text-white hover:bg-gray-900 transition-colors duration-200 border-b border-gray-800 last:border-b-0"
+          >
+            <div className="text-primary-blue mr-4">
+              {item.icon}
+            </div>
+            <span className="text-lg font-medium">{item.name}</span>
+            <div className="ml-auto text-gray-500">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MobileMenu;


### PR DESCRIPTION
## Summary
- Converted mobile menu from a separate page (/menu) to an inline component that opens as an overlay
- Created new MobileMenu component based on the existing MenuPage layout
- Updated Header component to use the new MobileMenu component instead of navigation
- Removed the /menu route from App.jsx as it's no longer needed

## Changes
- Added MobileMenu.jsx component with overlay functionality
- Modified Header.jsx to include mobile menu state and component
- Removed MenuPage import and route from App.jsx

## Test plan
- [x] Mobile menu button opens the overlay component
- [x] Menu items are displayed correctly with icons and navigation
- [x] Clicking menu items navigates and closes the overlay
- [x] Close button (X) closes the overlay
- [x] Build process completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)