### PR TITLE
fix(ui): ensure mobile menu has solid black background

### DIFF
--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -71,7 +71,7 @@ const MobileMenu = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/100 text-white">
+    <div className="fixed inset-0 z-50 bg-black text-white" style={{backgroundColor: '#000000'}}>
       {/* Header */}
       <div className="flex justify-between items-center h-16 px-4 border-b border-gray-800">
         <div className="text-xl font-bold text-primary-blue">


### PR DESCRIPTION
## Summary
- Fixed mobile menu background not appearing black on some devices
- Added inline style `backgroundColor: '#000000'` to guarantee black background
- Improved browser compatibility for mobile menu overlay

## Changes
- Modified MobileMenu.jsx to use both CSS class and inline style for black background
- Ensures consistent black background across different browsers and devices

## Test plan
- [x] Mobile menu now displays with solid black background
- [x] Background is consistently black across different browsers
- [x] Menu functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)