### PR TITLE
fix(ui): ensure mobile menu has complete black opacity

### DIFF
--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -71,7 +71,7 @@ const MobileMenu = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-black text-white" style={{backgroundColor: '#000000'}}>
+    <div className="fixed inset-0 z-50 bg-black text-white" style={{backgroundColor: '#000000', opacity: 1, zIndex: 9999}}>
       {/* Header */}
       <div className="flex justify-between items-center h-16 px-4 border-b border-gray-800">
         <div className="text-xl font-bold text-primary-blue">


### PR DESCRIPTION
## Summary
- Fixed mobile menu showing page content bleeding through background
- Added explicit opacity: 1 and zIndex: 9999 to ensure complete coverage
- Mobile menu now has completely opaque black background

## Problem
- Mobile menu was showing blue text from the page behind it
- Background wasn't completely opaque despite black color

## Solution
- Added inline styles: opacity: 1, zIndex: 9999
- Ensures mobile menu completely covers underlying content
- Maintains black background with full opacity

## Test plan
- [x] Mobile menu now shows solid black background
- [x] No page content visible behind menu overlay
- [x] Menu functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)